### PR TITLE
Logging in a subwiki with an user created on the main wiki would resolve the user as a subwiki user.

### DIFF
--- a/api/src/main/java/com/xwiki/identityoauth/internal/IdentityOAuthAuthService.java
+++ b/api/src/main/java/com/xwiki/identityoauth/internal/IdentityOAuthAuthService.java
@@ -50,8 +50,6 @@ import com.xpn.xwiki.web.XWikiRequest;
 @Singleton
 public class IdentityOAuthAuthService extends XWikiAuthServiceImpl
 {
-    private static final String XWIKISPACE = "XWiki.";
-
     @Inject
     private Logger log;
 
@@ -109,9 +107,6 @@ public class IdentityOAuthAuthService extends XWikiAuthServiceImpl
             if (userToLogin != null) {
                 log.debug("User to login found.");
                 sessionInfo.setUserToLogIn(null);
-                if (!userToLogin.startsWith(XWIKISPACE)) {
-                    userToLogin = XWIKISPACE + userToLogin;
-                }
                 log.debug("Authenticating user " + userToLogin);
                 return new SimplePrincipal(userToLogin);
             } else {

--- a/api/src/main/java/com/xwiki/identityoauth/internal/IdentityOAuthUserTools.java
+++ b/api/src/main/java/com/xwiki/identityoauth/internal/IdentityOAuthUserTools.java
@@ -37,6 +37,7 @@ import org.xwiki.contrib.oidc.auth.store.OIDCUserStore;
 import org.xwiki.model.reference.AttachmentReferenceResolver;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryManager;
 import org.xwiki.stability.Unstable;
@@ -76,6 +77,9 @@ public class IdentityOAuthUserTools implements IdentityOAuthConstants
     private DocumentReferenceResolver<String> documentResolver;
 
     @Inject
+    private EntityReferenceSerializer<String> serializer;
+
+    @Inject
     private AttachmentReferenceResolver<String> attachmentResolver;
 
     @Inject
@@ -102,7 +106,7 @@ public class IdentityOAuthUserTools implements IdentityOAuthConstants
         } else {
             xwikiUser = createUser(id, provider, token);
         }
-        return xwikiUser.getDocumentReference().getName();
+        return serializer.serialize(xwikiUser.getDocumentReference());
     }
 
     private XWikiDocument findExistingUser(IdentityOAuthProvider.AbstractIdentityDescription id)


### PR DESCRIPTION
After an investigation of this [Azure Integration Issue](https://github.com/xwikisas/integration-azure-oauth/issues/11) I found out that the user would not be able to access any page because he was resolved as a subwiki user, rather than global user.