### PR TITLE
Uninstalling a jar extension leaves the list of providers empty #16 

### DIFF
--- a/api/src/main/java/com/xwiki/identityoauth/internal/IdentityOAuthEventListener.java
+++ b/api/src/main/java/com/xwiki/identityoauth/internal/IdentityOAuthEventListener.java
@@ -84,11 +84,10 @@ public class IdentityOAuthEventListener extends AbstractEventListener
         if (log.isDebugEnabled()) {
             log.debug("Event! " + event + " from " + source);
         }
-        boolean applicationStarted = false;
+        boolean isManagerInitialized = false;
         boolean configChanged = false;
-        boolean providerAdded = false;
-        if (event instanceof ApplicationReadyEvent) {
-            applicationStarted = true;
+        if (event instanceof ApplicationReadyEvent || event instanceof ComponentDescriptorAddedEvent) {
+            isManagerInitialized = true;
         }
         if (event instanceof DocumentUpdatedEvent || event instanceof DocumentDeletedEvent) {
             XWikiDocument document = (XWikiDocument) source;
@@ -96,11 +95,8 @@ public class IdentityOAuthEventListener extends AbstractEventListener
                 configChanged = true;
             }
         }
-        if (event instanceof ComponentDescriptorAddedEvent) {
-            providerAdded = true;
-        }
 
-        if (configChanged || applicationStarted || providerAdded) {
+        if (configChanged || isManagerInitialized) {
             log.info("Reloading IdentityOAuth providers! ");
             identityOAuthManager.reloadConfig();
         }

--- a/api/src/main/java/com/xwiki/identityoauth/internal/IdentityOAuthEventListener.java
+++ b/api/src/main/java/com/xwiki/identityoauth/internal/IdentityOAuthEventListener.java
@@ -84,19 +84,18 @@ public class IdentityOAuthEventListener extends AbstractEventListener
         if (log.isDebugEnabled()) {
             log.debug("Event! " + event + " from " + source);
         }
-        boolean isManagerInitialized = false;
-        boolean configChanged = false;
+        boolean reloadConfig = false;
         if (event instanceof ApplicationReadyEvent || event instanceof ComponentDescriptorAddedEvent) {
-            isManagerInitialized = true;
+            reloadConfig = true;
         }
         if (event instanceof DocumentUpdatedEvent || event instanceof DocumentDeletedEvent) {
             XWikiDocument document = (XWikiDocument) source;
             if (document != null && ioXWikiObjects.hasIOConfigObject(document)) {
-                configChanged = true;
+                reloadConfig = true;
             }
         }
 
-        if (configChanged || isManagerInitialized) {
+        if (reloadConfig) {
             log.info("Reloading IdentityOAuth providers! ");
             identityOAuthManager.reloadConfig();
         }

--- a/api/src/main/java/com/xwiki/identityoauth/internal/IdentityOAuthSessionInfoProvider.java
+++ b/api/src/main/java/com/xwiki/identityoauth/internal/IdentityOAuthSessionInfoProvider.java
@@ -33,7 +33,7 @@ import com.xpn.xwiki.XWikiContext;
  *
  * @version $Id$
  * @since 1.0
- * */
+ */
 @Component
 @Singleton
 public class IdentityOAuthSessionInfoProvider implements Provider<IdentityOAuthSessionInfo>
@@ -41,15 +41,19 @@ public class IdentityOAuthSessionInfoProvider implements Provider<IdentityOAuthS
     @Inject
     private Provider<XWikiContext> contextProvider;
 
-    @Override public IdentityOAuthSessionInfo get()
+    @Override
+    public IdentityOAuthSessionInfo get()
     {
         String sessKey = IdentityOAuthSessionInfo.class.getName();
         HttpSession session = contextProvider.get().getRequest().getSession();
-        IdentityOAuthSessionInfo si = (IdentityOAuthSessionInfo) session.getAttribute(sessKey);
-        if (si == null) {
+        Object si = session.getAttribute(sessKey);
+        // When the classloader is recreated and components are re-initialized, an IdentityOAuthSessionInfo object
+        // using the old class is stored on the session.
+        if (!(si instanceof IdentityOAuthSessionInfo)) {
             si = new IdentityOAuthSessionInfo();
             session.setAttribute(sessKey, si);
         }
-        return si;
+
+        return (IdentityOAuthSessionInfo) si;
     }
 }


### PR DESCRIPTION
* reload saved configurations when a provider component is added
* recreate the IdentityOAuthSessionInfo stored on the session after classloader re-initialization