### PR TITLE
Error displayed when a previous login attempt was not finished #21

### DIFF
--- a/api/src/main/java/com/xwiki/identityoauth/internal/DefaultIdentityOAuthManager.java
+++ b/api/src/main/java/com/xwiki/identityoauth/internal/DefaultIdentityOAuthManager.java
@@ -360,7 +360,10 @@ public class DefaultIdentityOAuthManager
      */
     public boolean doesDetectReturn()
     {
-        return sessionInfoProvider.get().getProviderAuthorizationRunning() != null;
+        // Verify if the request contains an authorization code, to be sure it is an OAuth return. Check also for a
+        // running provider, which means the OAuth start was already processed.
+        return sessionInfoProvider.get().getProviderAuthorizationRunning() != null
+            && xwikiContextProvider.get().getRequest().getParameter("code") != null;
     }
 
     /**


### PR DESCRIPTION
* verify if the request contains an authorization code, to be sure it is an OAuth return; this is needed since on the first login try the running provider was set, but not removed when hitting the back button, so it wasn't a bulletproof condition