### PR TITLE
Improve escaping

### DIFF
--- a/ui/src/main/resources/IdentityOAuth/IdentityOAuthConfigMacros.vm
+++ b/ui/src/main/resources/IdentityOAuth/IdentityOAuthConfigMacros.vm
@@ -21,50 +21,52 @@
   #macro (initConfigObjects $configDocName $extraObjectClassPropPrefixes $translationPrefixesP)
     #set($formId = "${section.toLowerCase()}_${configDocName1}")
     #set($configDoc = $xwiki.getDocument($configDocName))
-
     #set($classNameIO="IdentityOAuth.IdentityOAuthConfigClass")
     #set($propNamePrefixIO="${configDoc.fullName}_${classNameIO}_0")
     #set($objIO = $configDoc.getObject($classNameIO))
-
+    ## Handle translation prefixes.
     #set($translationPrefixes = [])
     #foreach($p in $translationPrefixesP)
       #set($nuts=$translationPrefixes.add($p))
     #end
     #set($nuts=$translationPrefixes.add('IdentityOAuth.IdentityOAuthConfigClass_'))
-
+    ## Handle extra class properties.
     #foreach($x in $extraObjectClassPropPrefixes)
       #set($shhh = $x.add($x[0]))
       #set($x[0] = $configDoc.getObject($x[0]))
     #end
   #end
 
-
-  ## t: shorthand for translation
+  ##
+  ## Macros used in managing providers translations. t is for translation and tp for translation with parameters.
+  ##
   #macro (alignWithTranslationPrefixes $name)
     #set($tn = [])
     #foreach($p in $translationPrefixes)
       #set($nuts=$tn.add("${p}${name}"))
     #end
   #end
-  #macro (t $name $usage)
+  #macro (getTranslation $name $usage $translation)
     #alignWithTranslationPrefixes($name)
     #if ($usage == 'js')
-      $escapetool.javascript($services.localization.render($tn))
+      #set ($translation = $escapetool.javascript($services.localization.render($tn)))
     #else
-      $escapetool.xml($services.localization.render($tn))
+      #set ($translation = $escapetool.xml($services.localization.render($tn)))
     #end
   #end
-
-  ## tp: shorthand for translation with parameters
-  #macro (tp $name $params $usage)##
+  ## Display translation.
+  #macro (t $name $usage)
+    #getTranslation($name $usage $translation)
+    $translation
+  #end
+  ## Get translation with parameters.
+  #macro (tp $name $params $usage $translation)
     #alignWithTranslationPrefixes($name)
-    #set ($msg = $services.localization.render($tn,$params))##
-    ## convert to <a href="link">link-text</a> for the simple wiki syntax of links
-    #set ($msg = $stringtool.replacePattern($msg, '\[\[([^>]*)>>([^\]]*)\]\]', '<a href="$2">$1</a>'))##
+    #set ($msg = $services.localization.render($tn, $params))##
     #if ($usage == 'js')
-      $escapetool.javascript($msg)
+      #set ($translation = $escapetool.javascript($msg))
     #else
-      $escapetool.xml($msg)
+      #set ($translation = $escapetool.xml($msg))
     #end
   #end
 
@@ -102,7 +104,8 @@
       // absUrl: $absUrl
         #set($serverReturn = "${absUrl.substring(0, $absUrl.indexOf('/',8))}${serverReturn}")
       #end
-      window.placeHolderForRedirectUrl = '#tp("redirectUrl.placeHolderMessage", ["${serverReturn}"], "js")';
+      #tp("redirectUrl.placeHolderMessage", ["${serverReturn}"], "js", $translation)
+      window.placeHolderForRedirectUrl = "${translation}";
       var p = window.location.href.indexOf('/admin');
       window.browserReturnUrl = (p === -1 ?
               window.location.href :

--- a/ui/src/main/resources/IdentityOAuth/IdentityOAuthConfigMacros.vm
+++ b/ui/src/main/resources/IdentityOAuth/IdentityOAuthConfigMacros.vm
@@ -46,17 +46,26 @@
       #set($nuts=$tn.add("${p}${name}"))
     #end
   #end
-  #macro (t $name)
+  #macro (t $name $usage)
     #alignWithTranslationPrefixes($name)
-    $services.localization.render($tn)
+    #if ($usage == 'js')
+      $escapetool.javascript($services.localization.render($tn))
+    #else
+      $escapetool.xml($services.localization.render($tn))
+    #end
   #end
 
   ## tp: shorthand for translation with parameters
-  #macro (tp $name $params)##
+  #macro (tp $name $params $usage)##
     #alignWithTranslationPrefixes($name)
     #set ($msg = $services.localization.render($tn,$params))##
     ## convert to <a href="link">link-text</a> for the simple wiki syntax of links
-    $stringtool.replacePattern($msg, '\[\[([^>]*)>>([^\]]*)\]\]', '<a href="$2">$1</a>')##
+    #set ($msg = $stringtool.replacePattern($msg, '\[\[([^>]*)>>([^\]]*)\]\]', '<a href="$2">$1</a>'))##
+    #if ($usage == 'js')
+      $escapetool.javascript($msg)
+    #else
+      $escapetool.xml($msg)
+    #end
   #end
 
   ## displayInput: displays the form element of the relevant property of the object having removed the
@@ -93,7 +102,7 @@
       // absUrl: $absUrl
         #set($serverReturn = "${absUrl.substring(0, $absUrl.indexOf('/',8))}${serverReturn}")
       #end
-      window.placeHolderForRedirectUrl = '#tp("redirectUrl.placeHolderMessage", ["${serverReturn}"])';
+      window.placeHolderForRedirectUrl = '#tp("redirectUrl.placeHolderMessage", ["${serverReturn}"], "js")';
       var p = window.location.href.indexOf('/admin');
       window.browserReturnUrl = (p === -1 ?
               window.location.href :

--- a/ui/src/main/resources/IdentityOAuth/LoginUIExtension.vm
+++ b/ui/src/main/resources/IdentityOAuth/LoginUIExtension.vm
@@ -55,7 +55,7 @@
         #end
       #end
     #elseif ($request.identityOAuth)
-      #set ($statusMsg = "no such identityOAuth operation '${escapetool.xml($request.identityOAuth)}'")
+      #set ($statusMsg = "no such identityOAuth operation '$request.identityOAuth'")
     #else
       #set($statusMsg = "Login page")
       ## assemble the login code from the providers
@@ -90,7 +90,7 @@
       margin-bottom: 5%;
     }
     </style>
-    <!-- ======= ${statusMsg} ====== -->
+    <!-- ======= ${escapetool.xml($statusMsg)} ====== -->
 
     #if ($successMsg || $errorMsg)
     <script type="text/javascript">

--- a/ui/src/main/resources/IdentityOAuth/LoginUIExtension.vm
+++ b/ui/src/main/resources/IdentityOAuth/LoginUIExtension.vm
@@ -29,7 +29,7 @@
         #set($errorMsg = " ${errorMsg} ${services.localization.render('idoauth.login.domainerror2')} $!{email}.")
         #set($errorMsg = " ${errorMsg} ${services.localization.render('idoauth.login.domainerror3')}")
       #elseif ($result=="ok")
-        #set($successM = ${services.localization.render("idoauth.login.redirectmessage")})
+        #set ($successMsg = ${services.localization.render("idoauth.login.redirectmessage")})
         ## the browser should have been redirected by processOAuthReturn
       #else ## $result is "no user"
         #set($errorMsg = ${services.localization.render('idoauth.login.message')})
@@ -55,7 +55,7 @@
         #end
       #end
     #elseif ($request.identityOAuth)
-      #set($statusMsg = "no such identityOAuth operation '$request.identityOAuth'")
+      #set ($statusMsg = "no such identityOAuth operation '${escapetool.xml($request.identityOAuth)}'")
     #else
       #set($statusMsg = "Login page")
       ## assemble the login code from the providers

--- a/ui/src/main/resources/IdentityOAuth/Translations.de.properties
+++ b/ui/src/main/resources/IdentityOAuth/Translations.de.properties
@@ -6,8 +6,10 @@ IdentityOAuth.IdentityOAuthConfigClass_config.explanation=XWiki kann mit externe
 ## Adminstration interface
 IdentityOAuth.IdentityOAuthConfigClass_active=Aktivieren
 IdentityOAuth.IdentityOAuthConfigClass_communicate=Schnittstellen zu dem OAuth Provider
-IdentityOAuth.IdentityOAuthConfigClass_communicate.hint=Um eine OAuth Integration zu aktivieren, musst du {0}dein Wiki als App für den OAuth Zugang bei dem Provider registrieren{1} und die genannten Client-ID und Clientschlüssel in den folgenden Einstellungen einfügen.
-IdentityOAuth.IdentityOAuthConfigClass_communicate.hint2=Du erhälst mehr Information in den {0}Installationsanweisungen{1}.
+IdentityOAuth.IdentityOAuthConfigClass_communicate.hint=Um eine OAuth Integration zu aktivieren, musst du {0} und die genannten Client-ID und Clientschlüssel in den folgenden Einstellungen einfügen.
+IdentityOAuth.IdentityOAuthConfigClass_communicate.hint.linkLabel=dein Wiki als App für den OAuth Zugang bei dem Provider registrieren
+IdentityOAuth.IdentityOAuthConfigClass_communicate.hint2=Du erhälst mehr Information in den {0}.
+IdentityOAuth.IdentityOAuthConfigClass_communicate.hint2.linkLabel=Installationsanweisungen
 
 IdentityOAuth.IdentityOAuthConfigClass_appname=Name
 IdentityOAuth.IdentityOAuthConfigClass_appname.hint=Für deine eigene Organisation

--- a/ui/src/main/resources/IdentityOAuth/Translations.fr.properties
+++ b/ui/src/main/resources/IdentityOAuth/Translations.fr.properties
@@ -6,8 +6,10 @@ IdentityOAuth.IdentityOAuthConfigClass_config.explanation=XWiki peut être inté
 ## Adminstration interface
 IdentityOAuth.IdentityOAuthConfigClass_active=Activer
 IdentityOAuth.IdentityOAuthConfigClass_communicate=Communication avec les services OAuth
-IdentityOAuth.IdentityOAuthConfigClass_communicate.hint=Afin d''activer l''intégration OAuth vous devez vous enregistrer pour l''accès à OAuth chez le fournisseur et insérer les informations dans les paramètres suivants.
-IdentityOAuth.IdentityOAuthConfigClass_communicate.hint2=Voir aussi {0}les instructions d''installation{1}.
+IdentityOAuth.IdentityOAuthConfigClass_communicate.hint=Afin d''activer l''intégration OAuth vous devez {0} et insérer les informations dans les paramètres suivants.
+IdentityOAuth.IdentityOAuthConfigClass_communicate.hint.linkLabel=vous enregistrer pour l''accès à OAuth chez le fournisseur
+IdentityOAuth.IdentityOAuthConfigClass_communicate.hint2=Voir aussi {0}.
+IdentityOAuth.IdentityOAuthConfigClass_communicate.hint2.linkLabel=les instructions d''installation
 
 IdentityOAuth.IdentityOAuthConfigClass_appname=Nom de l'application
 IdentityOAuth.IdentityOAuthConfigClass_appname.hint=Pour votre propre organisation.

--- a/ui/src/main/resources/IdentityOAuth/Translations.properties
+++ b/ui/src/main/resources/IdentityOAuth/Translations.properties
@@ -70,8 +70,8 @@ idoauth.login.oauth.successwithredirect=Successful authentication. You are being
 idoauth.error.noValidLicense=A license for this application is missing. Please visit the License setting (in the Extensions section) to obtain one.
 idoauth.error.extensionDisabled=The IdentityOAuth integration is disabled on this wiki.
 
-idoauth.webHome.1=This is the code for the Identity OAuth extension, allowing to integrate XWiki with external provider's identities.
+idoauth.webHome.1=This is the code for the Identity OAuth extension, allowing to integrate XWiki with external provider identities.
 idoauth.webHome.2=...
 idoauth.webHome.3=...
-idoauth.webHome.4=Go to Provider's section of the XWiki Preferences in order to configure the application.
+idoauth.webHome.4=Go to the administration section of your specific provider in order to configure the application. 
 

--- a/ui/src/main/resources/IdentityOAuth/Translations.properties
+++ b/ui/src/main/resources/IdentityOAuth/Translations.properties
@@ -10,8 +10,10 @@ IdentityOAuth.IdentityOAuthConfigClass_config.explanation=XWiki can be integrate
 ## Adminstration interface
 IdentityOAuth.IdentityOAuthConfigClass_active=Activate
 IdentityOAuth.IdentityOAuthConfigClass_communicate=Communication with the OAuth service
-IdentityOAuth.IdentityOAuthConfigClass_communicate.hint=To activate an OAuth integration you need to {0}register for OAuth access to the provider''s configuration{1} and to insert your Client-Id and secret in the following settings.
-IdentityOAuth.IdentityOAuthConfigClass_communicate.hint2=For more information, please see {0}the installation instructions{1}.
+IdentityOAuth.IdentityOAuthConfigClass_communicate.hint=To activate an OAuth integration you need to {0} and to insert your Client-Id and secret in the following settings.
+IdentityOAuth.IdentityOAuthConfigClass_communicate.hint.linkLabel=register for OAuth access to the provider''s configuration
+IdentityOAuth.IdentityOAuthConfigClass_communicate.hint2=For more information, please see {0}.
+IdentityOAuth.IdentityOAuthConfigClass_communicate.hint2.linkLabel=the installation instructions
 
 IdentityOAuth.IdentityOAuthConfigClass_appname=Application Name
 IdentityOAuth.IdentityOAuthConfigClass_appname.hint=For your own organisation.

--- a/ui/src/main/resources/IdentityOAuth/WebHome.xml
+++ b/ui/src/main/resources/IdentityOAuth/WebHome.xml
@@ -46,13 +46,13 @@
 #if (!$services.licensing.licensor.hasLicensureForEntity($mainReference))
   {{error}}#getMissingLicenseMessage('idoauth.extension.name'){{/error}}
 #else
-	$services.localization.render('idoauth.webHome.1')
-	$services.localization.render('idoauth.webHome.2')
-	$services.localization.render('idoauth.webHome.3')
-  $services.localization.render('idoauth.webHome.4')
+  $escapetool.xml($services.localization.render('idoauth.webHome.1'))
+  $escapetool.xml($services.localization.render('idoauth.webHome.2'))
+  $escapetool.xml($services.localization.render('idoauth.webHome.3'))
+  $escapetool.xml($services.localization.render('idoauth.webHome.4'))
 #end
 
-[[=&gt; More about the IdentityOAuth Application>>https://store.xwiki.com/xwiki/bin/view/Extension/IdentityOAuth]].
+[[=&gt; More about the IdentityOAuth Application&gt;&gt;https://store.xwiki.com/xwiki/bin/view/Extension/IdentityOAuth]].
 {{/velocity}}
 </content>
   <attachment>


### PR DESCRIPTION
* add parameter for translations macros to specify where the translation is going to be used and add escaping for it
* improve escaping on the home page and update translations to avoid using `'`, which would be escaped
* add better escaping for statusMsg